### PR TITLE
Layout fixes

### DIFF
--- a/code/generate_webpage.py
+++ b/code/generate_webpage.py
@@ -98,7 +98,7 @@ for i in range(numPages):
         html += '\n      <div class="hieratic">'
         html += '\n        <img src="./images/hieratic_%s" />' % current_png_ref
         html += '\n      </div>'
-        html += '\n      <div class="hieroglyphic">'
+        html += '\n      <div class="hieroglyphic fade">'
         html += '\n        <img src="./images/hieroglyphic_%s" width="%ipx" %s/>' % (current_png_ref, width, maybe_flip)
         html += '\n      </div>'
         html += '\n    </div>'
@@ -132,6 +132,12 @@ document.addEventListener('DOMContentLoaded', (e) => {
   navbutton.addEventListener('mousedown', (click) => {
     document.querySelector('nav').classList.toggle('hidden');
   });
+  // Toggle transcription hiding.
+  for (element of document.getElementsByClassName('hieroglyphic')) {
+    element.addEventListener('click', (event) => {
+      event.target.parentElement.classList.toggle('fade');
+    });
+  }
 });
 </script>
 """

--- a/code/generate_webpage.py
+++ b/code/generate_webpage.py
@@ -125,21 +125,14 @@ nav += """      </ol>
 
 script = """
 <script>
+// Hook up event handlers after the page has loaded.
 document.addEventListener('DOMContentLoaded', (e) => {
+  // Navigation menu open/close.
   navbutton = document.querySelector('button');
   navbutton.addEventListener('mousedown', (click) => {
-    toggle_nav();
+    document.querySelector('nav').classList.toggle('hidden');
   });
 });
-
-function toggle_nav() {
-  nav = document.querySelector('nav');
-  if (nav.classList.contains('hidden')) {
-      nav.classList.remove('hidden');
-  } else {
-      nav.classList.add('hidden');
-  }
-}
 </script>
 """
 

--- a/docs/index.css
+++ b/docs/index.css
@@ -1,3 +1,7 @@
+/* set the overall layout direction */
+:root {
+  direction: rtl;
+}
 
 /* quick-link panel for navigation */
 .navbar {
@@ -16,7 +20,7 @@ nav {
 }
 
 nav.hidden {
-  translate: 5em;
+  translate: 7em;
 }
 
 .big {

--- a/docs/index.css
+++ b/docs/index.css
@@ -70,7 +70,7 @@ img.flip {
   display: inline-block;
   outline: 1px solid;
 }
-.hieroglyphic img {
+.fade img {
   opacity: 0;
   transition: opacity 200ms;
 }


### PR DESCRIPTION
- Click to keep a line of hieroglyphs visible
- Use `DOMTokenList.toggle` built-in
- Set overall page direction to `rtl` to try to get a better initial scroll position