### PR TITLE
set a max width

### DIFF
--- a/docs/index.css
+++ b/docs/index.css
@@ -43,7 +43,6 @@ nav a {
 }
 
 .container {
-  width: 3020px;
   padding: 0 20px;
   border: 0px solid red;
   /* Place block elements and text aligned on the right */
@@ -81,10 +80,7 @@ img.flip {
   opacity: 1;
 }
 
-/* Reduce container width and set a max width for lines */
-.container {
-    width: unset;
-}
+/* Set a max width for lines and scale to fit within that */
 img {
     width: 100%;
 }


### PR DESCRIPTION
Our source images are at different resolutions. Probably we should record specific scaling for each section, and rescale the images either at the source, or on display. That way we preserve any variations in the original document.

In the meantime, apply @randykomforty's css fixes to align everything to a maximum width, which at least keeps the page looking more orderly.